### PR TITLE
docs(strategy): rozbuduj rozdział Strategy (opis, przykład, diagram)

### DIFF
--- a/chapters/patterns/sdp/sdpb/strategy.md
+++ b/chapters/patterns/sdp/sdpb/strategy.md
@@ -10,21 +10,98 @@
 
 ## Description
 
-- Define more than one handlers
-- Use Cases (when to use this pattern)
-  - Making a decision which path will be better to handle params
+**Strategia** to wzorzec behawioralny: definiujesz rodzinę wymiennych
+algorytmów (strategii), zamykasz każdy z nich w osobnym obiekcie/funkcji
+i pozwalasz wybierać je w czasie działania programu. Klient operuje na
+wspólnym „interfejsie", a konkretną strategię podmienia jak część układanki.
+
+Sednem wzorca jest **zastąpienie rozgałęzień `if/else` (lub `switch`)** mapą
+algorytmów. Wybór ścieżki staje się danymi (kluczem w mapie), a nie kodem —
+więc dodanie nowego wariantu nie wymaga dotykania logiki wyboru.
+
+- Use Cases (kiedy stosować)
+  - Masz wiele wariantów „jak coś zrobić" wybieranych po wartości
+    (format pliku, metoda płatności, sposób sortowania, algorytm kompresji).
+  - Rozrastający się `switch`/`if-else` chcesz rozbić na niezależne kawałki.
+  - Chcesz testować każdy algorytm w izolacji.
 - Pros
-  - Decoupling code
-  - [Open-Closed Principle](chapters/patterns/solid/open-closed-principle.md)
+  - Eliminuje rozbudowane warunki — wybór to lookup w mapie.
+  - Luźne sprzężenie: klient nie zna szczegółów algorytmów.
+  - Spełnia [Open-Closed Principle](chapters/patterns/solid/open-closed-principle.md)
+    — nową strategię dodajesz, nie modyfikując istniejących.
 - Cons
-  - More files
-  - Complicated code
+  - Więcej drobnych plików/obiektów.
+  - Przerost dla 2–3 prostych przypadków (prosty `if` bywa czytelniejszy).
+
+## Diagram
+
+```mermaid
+flowchart LR
+    Client([Client]) -->|format = 'mp4'| Context[Context / lookup]
+    Context -->|map.get(format)| Registry[(Strategy Map)]
+    Registry --> S1["handleMp4()"]
+    Registry --> S2["handleMp3()"]
+    Registry --> S3["handleJpg()"]
+    S1 -.wybrana.-> Run[[wykonaj strategię]]
+```
+
+Zamiast `if format === 'mp4' … else if …`, kontekst pobiera funkcję z mapy
+po kluczu i ją wywołuje. Dodanie `webp` to `map.set('webp', …)` — bez zmian
+w kodzie wyboru.
+
+## Example
+
+### Problem — rosnący `if / else if`
+
+```js
+function handleMp4() { console.log("handle mp4 file"); }
+function handleMp3() { console.log("handle mp3 file"); }
+function handleJpg() { console.log("handle jpg file"); }
+
+const format = "mp4";
+
+if (format === "mp4") {
+  handleMp4();
+} else if (format === "mp3") {
+  handleMp3();
+} else if (format === "jpg") {
+  handleJpg();
+} else {
+  console.error("Unsupported format"); // każdy nowy format = nowy else-if
+}
+```
+
+Każdy nowy format wymusza edycję tej drabinki `if` — to łamie
+[Open-Closed Principle](chapters/patterns/solid/open-closed-principle.md).
+
+### Solution — mapa strategii
+
+```js
+const strategies = new Map();
+
+// każda strategia rejestruje się niezależnie (np. w osobnym pliku)
+strategies.set("mp4", () => console.log("handle mp4 file"));
+strategies.set("mp3", () => console.log("handle mp3 file"));
+strategies.set("jpg", () => console.log("handle jpg file"));
+
+// kontekst: wybór = lookup, nie rozgałęzienie
+function handleFile(format) {
+  const strategy = strategies.get(format);
+  if (!strategy) {
+    throw new Error(`Unsupported format: ${format}`);
+  }
+  return strategy();
+}
+
+handleFile("mp4"); // "handle mp4 file"
+
+// nowy format? jedna linijka, zero zmian w handleFile:
+strategies.set("webp", () => console.log("handle webp file"));
+```
 
 ## Resources
 
 - 🚀 <https://refactoring.guru/design-patterns/strategy>
-- <http://www.algorytm.org/wzorce-projektowe/strategia-strategy.html>
 - <https://www.dofactory.com/javascript/strategy-design-pattern>
-- PL: <http://adamczuk.net.pl/2012/02/10/wzorzec-projektowy-strategia/>
 - PL: <https://nafrontendzie.pl/wzorzec-strategia-w-javascript>
 - PL: <https://lukasz-socha.pl/php/wzorce-projektowe-cz-2-strategy/> (PHP)

--- a/chapters/patterns/sdp/sdpb/strategy.md
+++ b/chapters/patterns/sdp/sdpb/strategy.md
@@ -102,6 +102,8 @@ strategies.set("webp", () => console.log("handle webp file"));
 ## Resources
 
 - 🚀 <https://refactoring.guru/design-patterns/strategy>
+- PL: <http://www.algorytm.org/wzorce-projektowe/strategia-strategy.html>
 - <https://www.dofactory.com/javascript/strategy-design-pattern>
+- PL: <http://adamczuk.net.pl/2012/02/10/wzorzec-projektowy-strategia/>
 - PL: <https://nafrontendzie.pl/wzorzec-strategia-w-javascript>
 - PL: <https://lukasz-socha.pl/php/wzorce-projektowe-cz-2-strategy/> (PHP)

--- a/index.html
+++ b/index.html
@@ -39,7 +39,35 @@
           crossChapter: true,
           crossChapterText: true,
         },
+        markdown: {
+          renderer: {
+            code(code, lang) {
+              if (lang === "mermaid") {
+                return `<div class="mermaid">${code}</div>`;
+              }
+              return this.origin.code.apply(this, arguments);
+            },
+          },
+        },
+        plugins: [
+          function mermaidPlugin(hook) {
+            hook.doneEach(function () {
+              if (!window.mermaid) return;
+              const nodes = document.querySelectorAll(
+                ".mermaid:not([data-processed])"
+              );
+              if (nodes.length === 0) return;
+              // run() zwraca Promise — łapiemy odrzucenie, by konsola była czysta
+              Promise.resolve(window.mermaid.run({ nodes })).catch(() => {});
+            });
+          },
+        ],
       };
+    </script>
+    <script src="//unpkg.com/mermaid/dist/mermaid.min.js"></script>
+    <script>
+      window.mermaid &&
+        window.mermaid.initialize({ startOnLoad: false, theme: "default" });
     </script>
     <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
     <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>


### PR DESCRIPTION
Closes #6

Rozbudowuje rozdział **Strategy**:

- opisowy tekst po polsku
- przyklad kodu w ukladzie Problem -> Solution
- diagram (mermaid)

Dodatkowo wlacza wsparcie mermaid w `index.html` (renderer code + plugin doneEach), aby diagramy renderowaly sie w docsify. Zmiana `index.html` jest identyczna we wszystkich PR tej serii, wiec scala sie bezkonfliktowo niezaleznie od kolejnosci mergowania.