### PR TITLE
docs(adapter): rozbuduj rozdział Adapter (opis, przykład, diagram)

### DIFF
--- a/chapters/patterns/sdp/sdps/adapter.md
+++ b/chapters/patterns/sdp/sdps/adapter.md
@@ -10,23 +10,111 @@
 
 ## Description
 
-- Similar to [Facade Pattern](chapters/patterns/sdp/sdps/facade.md),
-  but **Adapter** requires two interfaces which will are integrated
-- Could be implemented as paradigm:
-  - **functional**, in every language
-  - **inheritance**, in languages that support multiple inheritance ex. C++
-- Use Cases (when to use this pattern)
-  - Wrap vendor to own interface
-  - Use legacy code, but you don't what to touch them
+**Adapter** (Wrapper) to wzorzec strukturalny, który pozwala współpracować
+obiektom o _niekompatybilnych interfejsach_. Adapter „tłumaczy" wywołania
+jednego interfejsu na drugi — jak przejściówka między wtyczką a gniazdkiem.
+
+Klient mówi w swoim języku (`request()`), a adapter zamienia to na to, co
+naprawdę rozumie obca/legacy klasa (`specificRequest()`). Kod klienta i kod
+biblioteki pozostają nietknięte.
+
+- Paradygmaty implementacji
+  - **kompozycja/funkcyjnie** — adapter trzyma referencję do obiektu i deleguje
+    (działa w każdym języku, preferowane w JS).
+  - **dziedziczenie** — adapter rozszerza adaptowaną klasę
+    (jak w `demo/adapter`, gdzie `PersonAdapter extends Person`).
+- Use Cases (kiedy stosować)
+  - Opakowanie zewnętrznej biblioteki we własny, stabilny interfejs.
+  - Korzystanie z legacy code, którego nie chcesz/nie możesz zmieniać.
+  - Ujednolicenie wielu różnych API pod jeden wspólny interfejs.
 - Pros
   - [Single Responsibility Principle](chapters/patterns/solid/single-responsibility-principle.md)
+    — konwersja interfejsu odizolowana w jednym miejscu.
   - [Open-Closed Principle](chapters/patterns/solid/open-closed-principle.md)
-  - Allows objects with incompatible interfaces to collaborate
-  - Adapter wraps one of the objects to hide the complexity of conversion happening behind the scenes
-  - Put the missing functionality (of Legacy Code) into an adapter class
+    — nowe adaptery dodajesz bez ruszania klienta.
+  - Pozwala współpracować klasom o niezgodnych interfejsach.
 - Cons
-  - Decrease performance
-  - Complicated code
+  - Dodatkowa warstwa pośrednia (mały narzut, więcej kodu).
+  - Przy wielu adapterach rośnie złożoność nawigacji po kodzie.
+
+### Adapter vs Facade
+
+- **Adapter** _dopasowuje_ istniejący interfejs do **konkretnego, oczekiwanego**
+  przez klienta — cel: zgodność.
+- [Facade](chapters/patterns/sdp/sdps/facade.md) _upraszcza_ — tworzy **nowy,
+  wygodniejszy** interfejs do całego podsystemu — cel: wygoda.
+
+## Diagram
+
+```mermaid
+classDiagram
+    class Client
+    class Target {
+        <<oczekiwany interfejs>>
+        +request()
+    }
+    class Adapter {
+        +request()
+    }
+    class Adaptee {
+        <<legacy / vendor>>
+        +specificRequest()
+    }
+    Client --> Target : woła request()
+    Target <|.. Adapter : implementuje
+    Adapter --> Adaptee : tłumaczy na specificRequest()
+```
+
+## Example
+
+### Problem — niekompatybilny interfejs
+
+Klasa `Person` przyjmuje imię i nazwisko sklejone w jeden string. My chcemy
+podawać je osobno — ale nie wolno nam zmieniać `Person` (np. to legacy/vendor).
+
+```js
+class Person {
+  constructor(name_surname) {
+    this.name_surname = name_surname;
+  }
+  getName() {
+    return this.name_surname;
+  }
+}
+
+const p = new Person("Piotr Kowalski");
+p.getName(); // "Piotr Kowalski"
+
+// Jak podać imię i nazwisko niezależnie, nie ruszając Person?
+```
+
+### Solution — adapter tłumaczy interfejs
+
+```js
+class Person {
+  constructor(name_surname) {
+    this.name_surname = name_surname;
+  }
+  getName() {
+    return this.name_surname;
+  }
+}
+
+// Adapter (przez dziedziczenie): nowy interfejs (name, surname)
+// tłumaczony na stary (name_surname)
+class PersonAdapter extends Person {
+  constructor(name, surname) {
+    super(`${name} ${surname}`);
+  }
+}
+
+const pa = new PersonAdapter("Piotr", "Kowalski");
+pa.getName(); // "Piotr Kowalski"
+```
+
+> 💡 Wariant z **kompozycją** (zamiast `extends`) jest zwykle bezpieczniejszy:
+> adapter trzyma `this._person = new Person(...)` i deleguje wywołania — nie
+> dziedziczy przypadkiem całego API klasy adaptowanej.
 
 ## Resources
 

--- a/index.html
+++ b/index.html
@@ -39,7 +39,35 @@
           crossChapter: true,
           crossChapterText: true,
         },
+        markdown: {
+          renderer: {
+            code(code, lang) {
+              if (lang === "mermaid") {
+                return `<div class="mermaid">${code}</div>`;
+              }
+              return this.origin.code.apply(this, arguments);
+            },
+          },
+        },
+        plugins: [
+          function mermaidPlugin(hook) {
+            hook.doneEach(function () {
+              if (!window.mermaid) return;
+              const nodes = document.querySelectorAll(
+                ".mermaid:not([data-processed])"
+              );
+              if (nodes.length === 0) return;
+              // run() zwraca Promise — łapiemy odrzucenie, by konsola była czysta
+              Promise.resolve(window.mermaid.run({ nodes })).catch(() => {});
+            });
+          },
+        ],
       };
+    </script>
+    <script src="//unpkg.com/mermaid/dist/mermaid.min.js"></script>
+    <script>
+      window.mermaid &&
+        window.mermaid.initialize({ startOnLoad: false, theme: "default" });
     </script>
     <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
     <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>


### PR DESCRIPTION
Closes #8

Rozbudowuje rozdział **Adapter**:

- opisowy tekst po polsku
- przyklad kodu w ukladzie Problem -> Solution
- diagram (mermaid)

Dodatkowo wlacza wsparcie mermaid w `index.html` (renderer code + plugin doneEach), aby diagramy renderowaly sie w docsify. Zmiana `index.html` jest identyczna we wszystkich PR tej serii, wiec scala sie bezkonfliktowo niezaleznie od kolejnosci mergowania.