### PR TITLE
docs(factory-method): wzbogać o wzorzec GoF (dziedziczenie, przykład, diagram)

### DIFF
--- a/chapters/patterns/sdp/sdpc/factory-method.md
+++ b/chapters/patterns/sdp/sdpc/factory-method.md
@@ -10,18 +10,148 @@
 
 ## Description
 
-- Separates product construction code from the code that actually uses the product
-- Subjects:
-  - creator, ex. Transport
-  - product, ex. Ship, Truck
-- Use Cases (when to use this pattern)
-  - Create data in unit tests
-  - When create library, and would like to extends internal implementation
+**Factory Method** to **wzorzec GoF**, który definiuje w klasie-twórcy (_creator_)
+metodę do tworzenia produktu, ale pozostawia **podklasom decyzję, jaką konkretną
+klasę produktu utworzyć**. Klasa bazowa zawiera logikę biznesową operującą na
+produkcie przez wspólny interfejs — a o tym, _który_ produkt powstanie,
+rozstrzyga nadpisana metoda fabryczna w podklasie.
+
+Kluczowy mechanizm to **dziedziczenie i polimorfizm**: to odróżnia go od
+[Simple Factory](chapters/patterns/sdp/sdpc/factory.md), gdzie wybór produktu
+robi jedna funkcja (najczęściej przez `if`/`switch`), bez podklas.
+
+> ⚠️ **Rozróżnienie:** zob.
+> [Simple Factory](chapters/patterns/sdp/sdpc/factory.md) (idiom, jedna funkcja)
+> oraz [Abstract Factory](chapters/patterns/sdp/sdpc/abstract-factory.md)
+> (rodziny produktów).
+
+- Subjects
+  - **creator** — klasa z metodą fabryczną, np. `Logistics`
+  - **product** — wspólny interfejs produktu, np. `Transport` (`Truck`, `Ship`)
+- Use Cases (kiedy stosować)
+  - Tworzysz bibliotekę/framework i chcesz, by użytkownik **nadpisał** sposób
+    tworzenia obiektów wewnętrznych.
+  - Klasa nie wie z góry, jakie obiekty produktów ma tworzyć — zależy to od
+    podklasy.
+  - Podstawianie atrap (mocków) w testach przez nadpisanie metody fabrycznej.
 - Pros
-  - The same method implemented in multi classes could be override, so from
-    outside there is no changes occur
+  - Ta sama metoda nadpisana w wielu podklasach → z zewnątrz nic się nie zmienia
+    ([Open-Closed Principle](chapters/patterns/solid/open-closed-principle.md)).
+  - Oddziela kod tworzenia produktu od kodu, który go używa.
 - Cons
-  - Complicated code
+  - Więcej klas i hierarchia dziedziczenia → bardziej złożony kod.
+  - Dla prostego „wybierz typ po stringu" wystarczy
+    [Simple Factory](chapters/patterns/sdp/sdpc/factory.md).
+
+## Diagram
+
+```mermaid
+classDiagram
+    class Logistics {
+        <<creator>>
+        +createTransport()* Transport
+        +planDelivery() string
+    }
+    class RoadLogistics {
+        +createTransport() Truck
+    }
+    class SeaLogistics {
+        +createTransport() Ship
+    }
+    class Transport {
+        <<interface>>
+        +deliver() string
+    }
+    class Truck { +deliver() }
+    class Ship { +deliver() }
+    Logistics <|-- RoadLogistics
+    Logistics <|-- SeaLogistics
+    Transport <|.. Truck
+    Transport <|.. Ship
+    RoadLogistics ..> Truck : tworzy
+    SeaLogistics ..> Ship : tworzy
+```
+
+`Logistics.planDelivery()` korzysta z produktu, ale **nie wie**, czy to `Truck`,
+czy `Ship` — decyduje o tym podklasa przez nadpisaną `createTransport()`.
+
+## Example
+
+### Problem — wybór produktu zaszyty w logice
+
+Logika biznesowa sama tworzy konkretne klasy. Dodanie nowego transportu wymusza
+edycję `planDelivery` — to łamie
+[Open-Closed Principle](chapters/patterns/solid/open-closed-principle.md).
+
+```js
+class Logistics {
+  planDelivery(type) {
+    let transport;
+    if (type === "road") {
+      transport = new Truck();
+    } else if (type === "sea") {
+      transport = new Ship(); // nowy transport = edycja tej metody
+    }
+    return transport.deliver();
+  }
+}
+```
+
+### Solution — metodę fabryczną nadpisują podklasy
+
+```js
+// Creator: definiuje metodę fabryczną i logikę biznesową na produkcie
+class Logistics {
+  // metoda fabryczna — podklasa MUSI ją nadpisać
+  createTransport() {
+    throw new Error("createTransport() must be implemented by a subclass");
+  }
+
+  // logika biznesowa nie wie, jaki konkretny produkt dostaje
+  planDelivery() {
+    const transport = this.createTransport();
+    return transport.deliver();
+  }
+}
+
+// Konkretni twórcy decydują o klasie produktu
+class RoadLogistics extends Logistics {
+  createTransport() {
+    return new Truck();
+  }
+}
+
+class SeaLogistics extends Logistics {
+  createTransport() {
+    return new Ship();
+  }
+}
+
+// Produkty ze wspólnym interfejsem
+class Truck {
+  deliver() {
+    return "deliver by road in a box";
+  }
+}
+
+class Ship {
+  deliver() {
+    return "deliver by sea in a container";
+  }
+}
+
+// --- użycie ---
+new RoadLogistics().planDelivery(); // "deliver by road in a box"
+new SeaLogistics().planDelivery(); // "deliver by sea in a container"
+
+// nowy transport = nowa podklasa, ZERO zmian w Logistics.planDelivery():
+class AirLogistics extends Logistics {
+  createTransport() {
+    return { deliver: () => "deliver by air" };
+  }
+}
+new AirLogistics().planDelivery(); // "deliver by air"
+```
 
 ## Resources
 

--- a/index.html
+++ b/index.html
@@ -39,7 +39,35 @@
           crossChapter: true,
           crossChapterText: true,
         },
+        markdown: {
+          renderer: {
+            code(code, lang) {
+              if (lang === "mermaid") {
+                return `<div class="mermaid">${code}</div>`;
+              }
+              return this.origin.code.apply(this, arguments);
+            },
+          },
+        },
+        plugins: [
+          function mermaidPlugin(hook) {
+            hook.doneEach(function () {
+              if (!window.mermaid) return;
+              const nodes = document.querySelectorAll(
+                ".mermaid:not([data-processed])"
+              );
+              if (nodes.length === 0) return;
+              // run() zwraca Promise — łapiemy odrzucenie, by konsola była czysta
+              Promise.resolve(window.mermaid.run({ nodes })).catch(() => {});
+            });
+          },
+        ],
       };
+    </script>
+    <script src="//unpkg.com/mermaid/dist/mermaid.min.js"></script>
+    <script>
+      window.mermaid &&
+        window.mermaid.initialize({ startOnLoad: false, theme: "default" });
     </script>
     <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
     <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>


### PR DESCRIPTION
Closes #17

Wzbogaca rozdzial **Factory Method** (wzorzec GoF) i odroznia go od `Simple Factory`:

- opis GoF: creator + product, nadpisywanie metody fabrycznej w podklasach
- przyklad Problem -> Solution z dziedziczeniem (Logistics -> Truck/Ship)
- diagram (mermaid)
- wzajemne linki Simple Factory <-> Factory Method

Para do PR #11 (Simple Factory). Wlacza tez wsparcie mermaid w `index.html` (identyczna zmiana jak w pozostalych PR tej serii, scala sie bezkonfliktowo).