### PR TITLE
feat: add search.namespace to docsify search config

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
           placeholder: "Wpisz frazę",
           noData: "Brak wyników",
           hideOtherSidebarContent: true,
+          namespace: "patterns-guide",
         },
         timeUpdater: {
           text: "<small style='color: grey; float: right'>Last update time: <strong>{docsify-updated}</strong></small>",


### PR DESCRIPTION
Adds `search.namespace` to the `window.$docsify` config, mirroring the `name` field (same pattern as finance-guide). A dedicated namespace gives the docsify search plugin its own localStorage key, so cached search indexes are rebuilt instead of reusing a stale shared key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)